### PR TITLE
Add user weight and settings screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,6 +74,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    // Needed for additional Material icons like ContentPaste
+    implementation("androidx.compose.material:material-icons-extended")
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/timeblock/data/Repository.kt
+++ b/app/src/main/java/com/example/timeblock/data/Repository.kt
@@ -14,11 +14,12 @@ import kotlinx.coroutines.flow.flow
 class Repository(private val userDao: UserDao, private val entryDao: EntryDao) {
 
     // User operations
-    suspend fun insertUser(displayName: String): User {
+    suspend fun insertUser(displayName: String, weight: String): User {
         val now = Instant.now()
         val user = User(
             userUuid = UUID.randomUUID().toString(),
             displayName = displayName,
+            weight = weight,
             timeCreated = now,
             timeModified = now
         )
@@ -29,6 +30,16 @@ class Repository(private val userDao: UserDao, private val entryDao: EntryDao) {
     suspend fun getUser(): User? {
         val users = userDao.getAllUsers()
         return users.firstOrNull()
+    }
+
+    suspend fun updateUser(user: User, newDisplayName: String, newWeight: String): User {
+        val updated = user.copy(
+            displayName = newDisplayName,
+            weight = newWeight,
+            timeModified = Instant.now()
+        )
+        userDao.updateUser(updated.displayName, updated.weight, updated.timeModified, updated.userUuid)
+        return updated
     }
 
     // Entry operations

--- a/app/src/main/java/com/example/timeblock/data/dao/UserDao.kt
+++ b/app/src/main/java/com/example/timeblock/data/dao/UserDao.kt
@@ -14,5 +14,8 @@ interface UserDao {
     @Query("SELECT * FROM User")
     suspend fun getAllUsers(): List<User>
 
+    @Query("UPDATE User SET display_name = :displayName, weight = :weight, time_modified = :timeModified WHERE user_uuid = :userUuid")
+    suspend fun updateUser(displayName: String, weight: String, timeModified: java.time.Instant, userUuid: String)
+
     // Add more methods as needed (e.g., update, delete, query by ID)
 }

--- a/app/src/main/java/com/example/timeblock/data/entity/User.kt
+++ b/app/src/main/java/com/example/timeblock/data/entity/User.kt
@@ -10,6 +10,7 @@ data class User(
     @PrimaryKey(autoGenerate = true) val primaryKey: Int = 0,
     @ColumnInfo(name = "user_uuid") val userUuid: String,
     @ColumnInfo(name = "display_name") val displayName: String,
+    @ColumnInfo(name = "weight") val weight: String = "0",
     @ColumnInfo(name = "time_created") val timeCreated: Instant,
     @ColumnInfo(name = "time_modified") val timeModified: Instant
 )

--- a/app/src/main/java/com/example/timeblock/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/timeblock/ui/MainViewModel.kt
@@ -25,6 +25,9 @@ class MainViewModel(private val repository: Repository) : ViewModel() {
     private val _isHistory = MutableStateFlow(false)
     val isHistory: StateFlow<Boolean> = _isHistory.asStateFlow()
 
+    private val _isSettings = MutableStateFlow(false)
+    val isSettings: StateFlow<Boolean> = _isSettings.asStateFlow()
+
     private val _allEntries = MutableStateFlow<List<Entry>>(emptyList())
     val allEntries: StateFlow<List<Entry>> = _allEntries.asStateFlow()
 
@@ -50,9 +53,9 @@ class MainViewModel(private val repository: Repository) : ViewModel() {
         }
     }
 
-    fun createUser(displayName: String) {
+    fun createUser(displayName: String, weight: String) {
         viewModelScope.launch {
-            val user = repository.insertUser(displayName)
+            val user = repository.insertUser(displayName, weight)
             _uiState.value = UiState.Ready(user)
             loadTodayEntry()
         }
@@ -88,6 +91,21 @@ class MainViewModel(private val repository: Repository) : ViewModel() {
 
     fun exitHistory() {
         _isHistory.value = false
+    }
+
+    fun openSettings() {
+        _isSettings.value = true
+    }
+
+    fun closeSettings() {
+        _isSettings.value = false
+    }
+
+    fun updateUser(user: User, displayName: String, weight: String) {
+        viewModelScope.launch {
+            val updated = repository.updateUser(user, displayName, weight)
+            _uiState.value = UiState.Ready(updated)
+        }
     }
 
     sealed class UiState {

--- a/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
+++ b/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.ContentPaste
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.*
@@ -34,8 +36,11 @@ fun LoadingScreen() {
 }
 
 @Composable
-fun UserSetupScreen(onUserCreated: (String) -> Unit) {
+fun UserSetupScreen(onUserCreated: (String, String) -> Unit) {
     var displayName by remember { mutableStateOf("") }
+    var weightValue by remember { mutableStateOf("") }
+    var expanded by remember { mutableStateOf(false) }
+    var selectedUnit by remember { mutableStateOf("kg") }
 
     Column(
         modifier = Modifier
@@ -65,12 +70,39 @@ fun UserSetupScreen(onUserCreated: (String) -> Unit) {
             modifier = Modifier.fillMaxWidth()
         )
 
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = weightValue,
+            onValueChange = { if (it.all { c -> c.isDigit() }) weightValue = it },
+            label = { Text("Weight") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Box {
+            OutlinedButton(onClick = { expanded = true }) {
+                Text(selectedUnit)
+            }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                DropdownMenuItem(text = { Text("kg") }, onClick = { selectedUnit = "kg"; expanded = false })
+                DropdownMenuItem(text = { Text("lbs") }, onClick = { selectedUnit = "lbs"; expanded = false })
+            }
+        }
+
         Spacer(modifier = Modifier.height(24.dp))
 
         Button(
             onClick = {
                 if (displayName.isNotBlank()) {
-                    onUserCreated(displayName)
+                    val weightString = if (weightValue.isNotBlank() && weightValue.toIntOrNull() != null && weightValue.toInt() > 0) {
+                        "$weightValue $selectedUnit"
+                    } else {
+                        "0"
+                    }
+                    onUserCreated(displayName, weightString)
                 }
             },
             enabled = displayName.isNotBlank(),
@@ -91,7 +123,10 @@ fun HomeScreen(
     onEditModeSelected: (MainViewModel.EditMode) -> Unit,
     onDismissDialog: () -> Unit,
     onUpdateValue: (Int, Boolean) -> Unit,
-    onViewHistory: () -> Unit
+    onViewHistory: () -> Unit,
+    onOpenSettings: () -> Unit,
+    showWeightPrompt: Boolean,
+    onWeightSet: (String) -> Unit
 ) {
     Column(
         modifier = Modifier
@@ -104,12 +139,15 @@ fun HomeScreen(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
+            IconButton(onClick = onOpenSettings) {
+                Icon(imageVector = Icons.Default.Settings, contentDescription = "Settings")
+            }
             Text(
                 text = "Hello, ${user.displayName}",
                 style = MaterialTheme.typography.headlineMedium
             )
-            TextButton(onClick = onViewHistory) {
-                Text("History")
+            IconButton(onClick = onViewHistory) {
+                Icon(imageVector = Icons.Default.ContentPaste, contentDescription = "History")
             }
         }
 
@@ -154,8 +192,8 @@ fun HomeScreen(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        TextButton(onClick = onViewHistory) {
-            Text("View History")
+        IconButton(onClick = onViewHistory) {
+            Icon(imageVector = Icons.Default.ContentPaste, contentDescription = "History")
         }
 
         // Bottom third with 3 buttons
@@ -199,6 +237,10 @@ fun HomeScreen(
             onUpdate = onUpdateValue,
             onViewHistory = onViewHistory
         )
+    }
+
+    if (showWeightPrompt) {
+        WeightDialog(onDismiss = {}, onSet = onWeightSet)
     }
 }
 
@@ -340,7 +382,122 @@ fun EditDialog(
 }
 
 @Composable
-fun HistoryScreen(entries: List<Entry>, onBack: () -> Unit) {
+fun WeightDialog(onDismiss: () -> Unit, onSet: (String) -> Unit) {
+    var weightValue by remember { mutableStateOf("") }
+    var expanded by remember { mutableStateOf(false) }
+    var unit by remember { mutableStateOf("kg") }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(shape = RoundedCornerShape(16.dp), color = MaterialTheme.colorScheme.surface) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Text(text = "Enter Weight", style = MaterialTheme.typography.headlineSmall)
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                OutlinedTextField(
+                    value = weightValue,
+                    onValueChange = { if (it.all { c -> c.isDigit() }) weightValue = it },
+                    label = { Text("Weight") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Box {
+                    OutlinedButton(onClick = { expanded = true }) { Text(unit) }
+                    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                        DropdownMenuItem(text = { Text("kg") }, onClick = { unit = "kg"; expanded = false })
+                        DropdownMenuItem(text = { Text("lbs") }, onClick = { unit = "lbs"; expanded = false })
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    Button(onClick = {
+                        val w = if (weightValue.isNotBlank() && weightValue.toIntOrNull() != null && weightValue.toInt() > 0) {
+                            "$weightValue $unit"
+                        } else {
+                            "0"
+                        }
+                        onSet(w)
+                    }) {
+                        Text("Set")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingsScreen(user: User, onSave: (String, String) -> Unit, onBack: () -> Unit) {
+    var name by remember { mutableStateOf(user.displayName) }
+    var weightVal by remember { mutableStateOf(user.weight.takeWhile { it.isDigit() }) }
+    var expanded by remember { mutableStateOf(false) }
+    var unit by remember { mutableStateOf(if (user.weight.endsWith("lbs")) "lbs" else "kg") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            IconButton(onClick = onBack) {
+                Icon(imageVector = Icons.Default.ArrowBack, contentDescription = "Back")
+            }
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(text = "Settings", style = MaterialTheme.typography.headlineMedium)
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text("Display Name") },
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedTextField(
+            value = weightVal,
+            onValueChange = { if (it.all { c -> c.isDigit() }) weightVal = it },
+            label = { Text("Weight") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Box {
+            OutlinedButton(onClick = { expanded = true }) { Text(unit) }
+            DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                DropdownMenuItem(text = { Text("kg") }, onClick = { unit = "kg"; expanded = false })
+                DropdownMenuItem(text = { Text("lbs") }, onClick = { unit = "lbs"; expanded = false })
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Button(
+            onClick = {
+                val weightString = if (weightVal.isNotBlank() && weightVal.toIntOrNull() != null && weightVal.toInt() > 0) {
+                    "$weightVal $unit"
+                } else {
+                    "0"
+                }
+                onSave(name, weightString)
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) { Text("Save") }
+    }
+}
+
+@Composable
+fun HistoryScreen(entries: List<Entry>, weight: String, onBack: () -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -383,10 +540,19 @@ fun HistoryScreen(entries: List<Entry>, onBack: () -> Unit) {
                             ldt.hour,
                             ldt.minute
                         )
-                        Text(
-                            text = "Date: $formattedDate",
-                            style = MaterialTheme.typography.bodySmall
-                        )
+                        Row(modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                text = "Date: $formattedDate",
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.weight(1f)
+                            )
+                            Text(
+                                text = weight,
+                                style = MaterialTheme.typography.bodySmall,
+                                textAlign = TextAlign.End,
+                                modifier = Modifier.weight(1f)
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- prompt for display name and weight when app starts
- show buttons for settings and history
- display weight in history items
- add settings screen to edit display name or weight
- keep weight stored as text in Room entity
- include Material Icons dependency for clipboard icon

## Testing
- `./gradlew compileAll` *(fails: No route to host)*