### PR TITLE
Handle numeric-only weight strings

### DIFF
--- a/app/src/main/java/com/example/timeblock/util/WeightUtils.kt
+++ b/app/src/main/java/com/example/timeblock/util/WeightUtils.kt
@@ -9,11 +9,25 @@ data class Weight(val value: Double, val unit: Unit) {
 
 /** Parse a string like "70 kg" or "150 lbs" into a [Weight] object. */
 fun parseWeight(weightString: String): Weight? {
-    val regex = Regex("""([0-9]+(?:\\.[0-9]+)?)\\s*(kg|lbs)""", RegexOption.IGNORE_CASE)
-    val match = regex.find(weightString.trim()) ?: return null
-    val value = match.groupValues[1].toDoubleOrNull() ?: return null
-    val unit = if (match.groupValues[2].lowercase() == "kg") Weight.Unit.KG else Weight.Unit.LBS
-    return Weight(value, unit)
+    val trimmed = weightString.trim().lowercase()
+
+    // Accept common variations like "kg", "kgs", "kilogram", "pounds", etc.
+    val regex = Regex("""([0-9]+(?:\\.[0-9]+)?)\\s*(kg|kgs?|kilograms?|lb|lbs?|pounds?)""")
+    val match = regex.find(trimmed)
+    if (match != null) {
+        val value = match.groupValues[1].toDoubleOrNull() ?: return null
+        val unitStr = match.groupValues[2]
+        val unit = if (unitStr.startsWith("kg")) Weight.Unit.KG else Weight.Unit.LBS
+        return Weight(value, unit)
+    }
+
+    // Fallback: if the string only contains digits, assume kilograms
+    val numeric = trimmed.toDoubleOrNull()
+    if (numeric != null) {
+        return Weight(numeric, Weight.Unit.KG)
+    }
+
+    return null
 }
 
 /** Calculate the recommended protein goal in grams for the given weight. */

--- a/app/src/test/java/com/example/timeblock/util/WeightUtilsTest.kt
+++ b/app/src/test/java/com/example/timeblock/util/WeightUtilsTest.kt
@@ -1,0 +1,28 @@
+package com.example.timeblock.util
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class WeightUtilsTest {
+    @Test
+    fun parseCommonFormats() {
+        assertEquals(234, parseWeight("234kg")!!.value.toInt())
+        assertEquals(234, parseWeight("234 kg")!!.value.toInt())
+        assertEquals(234, parseWeight("234 kgs")!!.value.toInt())
+        assertEquals(234, parseWeight("234 kilograms")!!.value.toInt())
+        assertEquals(100, parseWeight("100 lb")!!.value.toInt())
+        assertEquals(100, parseWeight("100 lbs")!!.value.toInt())
+        assertEquals(100, parseWeight("100 pounds")!!.value.toInt())
+    }
+
+    @Test
+    fun parseNumericOnly() {
+        assertEquals(50, parseWeight("50")!!.value.toInt())
+    }
+
+    @Test
+    fun invalidInput() {
+        assertNull(parseWeight("abc"))
+    }
+}


### PR DESCRIPTION
## Summary
- be more forgiving when parsing weight
- add unit tests for parseWeight covering various formats

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*