### PR TITLE
Add daily refresh mechanism

### DIFF
--- a/app/src/main/java/com/example/timeblock/MainActivity.kt
+++ b/app/src/main/java/com/example/timeblock/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.ViewModelProvider
 import com.example.timeblock.data.AppDatabase
 import com.example.timeblock.data.Repository
 import com.example.timeblock.ui.MainViewModel
@@ -22,12 +22,16 @@ import com.example.timeblock.ui.screens.SettingsScreen
 import com.example.timeblock.ui.theme.TimeBlockTheme
 
 class MainActivity : ComponentActivity() {
+
+    private lateinit var viewModel: MainViewModel
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         val database = AppDatabase.getDatabase(applicationContext)
         val repository = Repository(database.userDao(), database.entryDao())
         val viewModelFactory = MainViewModel.MainViewModelFactory(repository)
+        viewModel = ViewModelProvider(this, viewModelFactory)[MainViewModel::class.java]
 
         setContent {
             TimeBlockTheme {
@@ -35,16 +39,20 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    TimeBlockApp(viewModelFactory)
+                    TimeBlockApp(viewModel)
                 }
             }
         }
     }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.refreshForDateChange()
+    }
 }
 
 @Composable
-fun TimeBlockApp(viewModelFactory: MainViewModel.MainViewModelFactory) {
-    val viewModel: MainViewModel = viewModel(factory = viewModelFactory)
+fun TimeBlockApp(viewModel: MainViewModel) {
     val uiState by viewModel.uiState.collectAsState()
     val isHistory by viewModel.isHistory.collectAsState()
     val isSettings by viewModel.isSettings.collectAsState()

--- a/app/src/main/java/com/example/timeblock/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/timeblock/ui/MainViewModel.kt
@@ -3,6 +3,7 @@ package com.example.timeblock.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import java.time.LocalDate
 import com.example.timeblock.data.Repository
 import com.example.timeblock.data.entity.Entry
 import com.example.timeblock.data.entity.User
@@ -12,6 +13,8 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class MainViewModel(private val repository: Repository) : ViewModel() {
+
+    private var lastLoadedDay: LocalDate? = null
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
     val uiState: StateFlow<UiState> = _uiState.asStateFlow()
@@ -50,6 +53,14 @@ class MainViewModel(private val repository: Repository) : ViewModel() {
     private fun loadTodayEntry() {
         viewModelScope.launch {
             _trackingData.value = repository.getOrCreateTodayEntry()
+            lastLoadedDay = LocalDate.now()
+        }
+    }
+
+    fun refreshForDateChange() {
+        val today = LocalDate.now()
+        if (lastLoadedDay != today) {
+            loadTodayEntry()
         }
     }
 


### PR DESCRIPTION
## Summary
- track last loaded day in `MainViewModel`
- reload today's entry when the date changes
- expose `refreshForDateChange` and call from `MainActivity.onResume`
- reuse the same `MainViewModel` instance in the activity

## Testing
- `./gradlew compileAll` *(fails: No route to host)*