### PR TITLE
Remove Android log dependency in WeightUtils

### DIFF
--- a/app/src/main/java/com/example/timeblock/util/WeightUtils.kt
+++ b/app/src/main/java/com/example/timeblock/util/WeightUtils.kt
@@ -10,9 +10,9 @@ data class Weight(val value: Double, val unit: Unit) {
 /** Parse a string like "70 kg" or "150 lbs" into a [Weight] object. */
 fun parseWeight(weightString: String): Weight? {
     val regex = Regex("""([0-9]+(?:\.[0-9]+)?)\s*(kg|lbs)""", RegexOption.IGNORE_CASE)
-    android.util.Log.d("WeightUtils", "Parsing weight: '$weightString'")
+    println("Parsing weight: '$weightString'")
     val match = regex.find(weightString.trim())
-    android.util.Log.d("WeightUtils", "Match result: $match")
+    println("Match result: $match")
     val matchResult = match ?: return null
     val value = matchResult.groupValues[1].toDoubleOrNull() ?: return null
     val unit = if (matchResult.groupValues[2].lowercase() == "kg") Weight.Unit.KG else Weight.Unit.LBS


### PR DESCRIPTION
## Summary
- replace `android.util.Log` calls in `WeightUtils` with multiplatform-friendly `println`

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*