### PR TITLE
Add history range filters and chart

### DIFF
--- a/app/src/main/java/com/example/timeblock/data/Repository.kt
+++ b/app/src/main/java/com/example/timeblock/data/Repository.kt
@@ -7,6 +7,7 @@ import com.example.timeblock.data.entity.User
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -105,6 +106,12 @@ class Repository(private val userDao: UserDao, private val entryDao: EntryDao) {
 
     fun getAllEntriesFlow(): Flow<List<Entry>> = flow {
         emit(getAllEntries())
+    }
+
+    suspend fun getEntriesSince(days: Long): List<Entry> {
+        val end = Instant.now()
+        val start = end.minus(days, ChronoUnit.DAYS)
+        return entryDao.getEntriesBetween(start, end)
     }
 
 

--- a/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
@@ -10,18 +10,27 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+enum class HistoryRange { MAX, DAYS_30, DAYS_5 }
+
 class HistoryViewModel(private val repository: Repository) : ViewModel() {
 
     private val _entries = MutableStateFlow<List<Entry>>(emptyList())
     val entries: StateFlow<List<Entry>> = _entries.asStateFlow()
 
+    private var currentRange: HistoryRange = HistoryRange.MAX
+
     init {
         loadEntries()
     }
 
-    private fun loadEntries() {
+    fun loadEntries(range: HistoryRange = currentRange) {
         viewModelScope.launch {
-            _entries.value = repository.getAllEntries()
+            currentRange = range
+            _entries.value = when (range) {
+                HistoryRange.MAX -> repository.getAllEntries()
+                HistoryRange.DAYS_30 -> repository.getEntriesSince(30)
+                HistoryRange.DAYS_5 -> repository.getEntriesSince(5)
+            }
         }
     }
 

--- a/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
+++ b/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
@@ -13,7 +13,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.Canvas
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
@@ -24,6 +29,8 @@ import androidx.compose.ui.window.Dialog
 import com.example.timeblock.data.entity.Entry
 import com.example.timeblock.data.entity.User
 import com.example.timeblock.ui.MainViewModel
+import com.example.timeblock.ui.HistoryViewModel
+import com.example.timeblock.ui.HistoryRange
 import com.example.timeblock.util.proteinGoalForWeightString
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -319,6 +326,22 @@ fun TrackingButton(
 }
 
 @Composable
+fun FilterButton(label: String, selected: Boolean, modifier: Modifier = Modifier, onClick: () -> Unit) {
+    val colors = if (selected) {
+        ButtonDefaults.buttonColors()
+    } else {
+        ButtonDefaults.outlinedButtonColors()
+    }
+    Button(
+        onClick = onClick,
+        colors = colors,
+        modifier = modifier
+    ) {
+        Text(label)
+    }
+}
+
+@Composable
 fun EditDialog(
     mode: MainViewModel.EditMode,
     currentValue: Int,
@@ -550,7 +573,34 @@ fun SettingsScreen(user: User, onSave: (String, String) -> Unit, onBack: () -> U
 }
 
 @Composable
-fun HistoryScreen(entries: List<Entry>, weight: String, onBack: () -> Unit) {
+fun HistoryChart(entries: List<Entry>, modifier: Modifier = Modifier) {
+    val maxValue = entries.maxOfOrNull { it.proteinGrams } ?: 0
+    val density = LocalDensity.current
+    val barWidthPx = with(density) { 16.dp.toPx() }
+    val spacePx = with(density) { 4.dp.toPx() }
+
+    Canvas(modifier = modifier.height(150.dp).fillMaxWidth()) {
+        val maxHeight = size.height
+        val totalWidth = entries.size * barWidthPx + (entries.size - 1) * spacePx
+        val startX = (size.width - totalWidth).coerceAtLeast(0f) / 2f
+
+        entries.forEachIndexed { index, entry ->
+            val barHeight = if (maxValue == 0) 0f else (entry.proteinGrams / maxValue.toFloat()) * maxHeight
+            val x = startX + index * (barWidthPx + spacePx)
+            drawRect(
+                color = MaterialTheme.colorScheme.primary,
+                topLeft = Offset(x, size.height - barHeight),
+                size = Size(barWidthPx, barHeight)
+            )
+        }
+    }
+}
+
+@Composable
+fun HistoryScreen(viewModel: HistoryViewModel, weight: String, onBack: () -> Unit) {
+    val entries by viewModel.entries.collectAsState()
+    var range by remember { mutableStateOf(HistoryRange.MAX) }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -566,6 +616,30 @@ fun HistoryScreen(entries: List<Entry>, weight: String, onBack: () -> Unit) {
                 style = MaterialTheme.typography.headlineMedium
             )
         }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            FilterButton("MAX", range == HistoryRange.MAX, modifier = Modifier.weight(1f)) {
+                range = HistoryRange.MAX
+                viewModel.loadEntries(HistoryRange.MAX)
+            }
+            FilterButton("30d", range == HistoryRange.DAYS_30, modifier = Modifier.weight(1f)) {
+                range = HistoryRange.DAYS_30
+                viewModel.loadEntries(HistoryRange.DAYS_30)
+            }
+            FilterButton("5d", range == HistoryRange.DAYS_5, modifier = Modifier.weight(1f)) {
+                range = HistoryRange.DAYS_5
+                viewModel.loadEntries(HistoryRange.DAYS_5)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        HistoryChart(entries)
 
         Spacer(modifier = Modifier.height(16.dp))
 


### PR DESCRIPTION
## Summary
- extend `HistoryViewModel` with `HistoryRange` and load by range
- allow repository to fetch entries from last N days
- draw a simple bar chart in `HistoryScreen`
- add filter buttons in history view
- wire `HistoryViewModel` into `MainActivity`

## Testing
- `./gradlew compileAll` *(fails: No route to host)*