### PR TITLE
Add basic home screen widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# TimeBlock
+
+This app tracks daily protein, vegetable servings and steps. It now includes a home screen widget for quick updates.
+
+## Widget Setup
+
+1. Install the app on your device.
+2. Long‑press on the home screen and choose **Widgets**.
+3. Find **TimeBlock** in the widget list and drag it to your home screen.
+4. Tap a value to open the app directly to its edit dialog.
+5. Use the **+** buttons to quickly add to protein, veggies or steps. The widget and database update immediately.
+
+The widget requires at least a 2×2 space.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,5 +23,19 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name=".widget.TimeBlockWidgetProvider"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/timeblock_widget_info" />
+        </receiver>
+        <receiver
+            android:name=".widget.WidgetReceiver"
+            android:exported="false" />
     </application>
 </manifest>

--- a/app/src/main/java/com/example/timeblock/widget/TimeBlockWidgetProvider.kt
+++ b/app/src/main/java/com/example/timeblock/widget/TimeBlockWidgetProvider.kt
@@ -1,0 +1,101 @@
+package com.example.timeblock.widget
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.widget.RemoteViews
+import com.example.timeblock.MainActivity
+import com.example.timeblock.R
+import com.example.timeblock.data.AppDatabase
+import com.example.timeblock.data.Repository
+import com.example.timeblock.ui.MainViewModel
+import kotlinx.coroutines.runBlocking
+
+class TimeBlockWidgetProvider : AppWidgetProvider() {
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        for (appWidgetId in appWidgetIds) {
+            updateAppWidget(context, appWidgetManager, appWidgetId)
+        }
+    }
+
+    companion object {
+        const val ACTION_INCREMENT_PROTEIN = "com.example.timeblock.action.INCREMENT_PROTEIN"
+        const val ACTION_INCREMENT_VEGGIES = "com.example.timeblock.action.INCREMENT_VEGGIES"
+        const val ACTION_INCREMENT_STEPS = "com.example.timeblock.action.INCREMENT_STEPS"
+        const val EXTRA_EDIT_MODE = "com.example.timeblock.extra.EDIT_MODE"
+
+        fun updateAllWidgets(context: Context) {
+            val manager = AppWidgetManager.getInstance(context)
+            val component = ComponentName(context, TimeBlockWidgetProvider::class.java)
+            val ids = manager.getAppWidgetIds(component)
+            for (id in ids) {
+                updateAppWidget(context, manager, id)
+            }
+        }
+
+        fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
+            val db = AppDatabase.getDatabase(context)
+            val repository = Repository(db.userDao(), db.entryDao())
+            val entry = runBlocking { repository.getOrCreateTodayEntry() }
+
+            val views = RemoteViews(context.packageName, R.layout.timeblock_widget)
+            views.setTextViewText(R.id.widget_protein_value, "${entry.proteinGrams}g")
+            views.setTextViewText(R.id.widget_veggies_value, "${entry.vegetableServings}")
+            views.setTextViewText(R.id.widget_steps_value, "${entry.steps}")
+
+            views.setOnClickPendingIntent(
+                R.id.widget_protein_add,
+                getBroadcastPendingIntent(context, ACTION_INCREMENT_PROTEIN)
+            )
+            views.setOnClickPendingIntent(
+                R.id.widget_veggies_add,
+                getBroadcastPendingIntent(context, ACTION_INCREMENT_VEGGIES)
+            )
+            views.setOnClickPendingIntent(
+                R.id.widget_steps_add,
+                getBroadcastPendingIntent(context, ACTION_INCREMENT_STEPS)
+            )
+
+            views.setOnClickPendingIntent(
+                R.id.widget_protein_value,
+                getActivityPendingIntent(context, MainViewModel.EditMode.PROTEIN)
+            )
+            views.setOnClickPendingIntent(
+                R.id.widget_veggies_value,
+                getActivityPendingIntent(context, MainViewModel.EditMode.VEGETABLES)
+            )
+            views.setOnClickPendingIntent(
+                R.id.widget_steps_value,
+                getActivityPendingIntent(context, MainViewModel.EditMode.STEPS)
+            )
+
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+
+        private fun getBroadcastPendingIntent(context: Context, action: String): PendingIntent {
+            val intent = Intent(context, WidgetReceiver::class.java).apply { this.action = action }
+            return PendingIntent.getBroadcast(
+                context,
+                action.hashCode(),
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        }
+
+        private fun getActivityPendingIntent(context: Context, mode: MainViewModel.EditMode): PendingIntent {
+            val intent = Intent(context, MainActivity::class.java).apply {
+                putExtra(EXTRA_EDIT_MODE, mode.name)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            }
+            return PendingIntent.getActivity(
+                context,
+                mode.ordinal,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/timeblock/widget/WidgetReceiver.kt
+++ b/app/src/main/java/com/example/timeblock/widget/WidgetReceiver.kt
@@ -1,0 +1,39 @@
+package com.example.timeblock.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import com.example.timeblock.data.AppDatabase
+import com.example.timeblock.data.Repository
+import kotlinx.coroutines.runBlocking
+
+class WidgetReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            TimeBlockWidgetProvider.ACTION_INCREMENT_PROTEIN -> {
+                updateEntry(context) { repo -> runBlocking { repo.updateProtein(1, true) } }
+            }
+            TimeBlockWidgetProvider.ACTION_INCREMENT_VEGGIES -> {
+                updateEntry(context) { repo -> runBlocking { repo.updateVegetables(1, true) } }
+            }
+            TimeBlockWidgetProvider.ACTION_INCREMENT_STEPS -> {
+                updateEntry(context) { repo -> runBlocking { repo.updateSteps(100, true) } }
+            }
+        }
+        super.onReceive(context, intent)
+    }
+
+    private fun updateEntry(context: Context, block: (Repository) -> Unit) {
+        val db = AppDatabase.getDatabase(context)
+        val repository = Repository(db.userDao(), db.entryDao())
+        block(repository)
+        val manager = AppWidgetManager.getInstance(context)
+        val component = ComponentName(context, TimeBlockWidgetProvider::class.java)
+        val ids = manager.getAppWidgetIds(component)
+        for (id in ids) {
+            TimeBlockWidgetProvider.updateAppWidget(context, manager, id)
+        }
+    }
+}

--- a/app/src/main/res/layout/timeblock_widget.xml
+++ b/app/src/main/res/layout/timeblock_widget.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="8dp"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+        <TextView
+            android:id="@+id/widget_protein_label"
+            android:text="Protein:"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+        <TextView
+            android:id="@+id/widget_protein_value"
+            android:text="0g"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="4dp"
+            android:clickable="true" />
+        <Button
+            android:id="@+id/widget_protein_add"
+            android:text="+"
+            android:layout_width="40dp"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_marginTop="4dp">
+        <TextView
+            android:id="@+id/widget_veggies_label"
+            android:text="Veggies:"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+        <TextView
+            android:id="@+id/widget_veggies_value"
+            android:text="0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="4dp"
+            android:clickable="true" />
+        <Button
+            android:id="@+id/widget_veggies_add"
+            android:text="+"
+            android:layout_width="40dp"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_marginTop="4dp">
+        <TextView
+            android:id="@+id/widget_steps_label"
+            android:text="Steps:"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+        <TextView
+            android:id="@+id/widget_steps_value"
+            android:text="0"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="4dp"
+            android:clickable="true" />
+        <Button
+            android:id="@+id/widget_steps_add"
+            android:text="+"
+            android:layout_width="40dp"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/xml/timeblock_widget_info.xml
+++ b/app/src/main/res/xml/timeblock_widget_info.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="110dp"
+    android:updatePeriodMillis="0"
+    android:previewImage="@drawable/ic_launcher_foreground"
+    android:initialLayout="@layout/timeblock_widget"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
## Summary
- add app widget provider and receiver to update protein, veggie, and step counts
- show counts and `+` buttons via new layout
- hook widget into `MainActivity` so tapping values opens edit dialog
- update manifest and document widget setup in README

## Testing
- `./gradlew compileAll` *(fails: No route to host)*