### PR TITLE
Add scoring utilities and sharing

### DIFF
--- a/app/src/main/java/com/example/timeblock/util/ScoreUtils.kt
+++ b/app/src/main/java/com/example/timeblock/util/ScoreUtils.kt
@@ -1,0 +1,40 @@
+package com.example.timeblock.util
+
+import com.example.timeblock.data.entity.Entry
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/** Utility functions for computing a daily score based on tracking data. */
+object ScoreUtils {
+    /**
+     * Calculate a score from the given metrics. Values are capped at 100.
+     */
+    fun calculateScore(
+        proteinGrams: Int,
+        proteinGoal: Int,
+        veggieServings: Int,
+        veggieGoal: Int = 5,
+        steps: Int,
+        stepsGoal: Int = 8500
+    ): Int {
+        if (proteinGoal <= 0 || veggieGoal <= 0 || stepsGoal <= 0) return 0
+        val p = min(proteinGrams.toDouble() / proteinGoal, 1.0)
+        val v = min(veggieServings.toDouble() / veggieGoal, 1.0)
+        val s = min(steps.toDouble() / stepsGoal, 1.0)
+        return ((p + v + s) / 3.0 * 100).roundToInt()
+    }
+
+    /** Convenience wrapper that calculates the score for an [Entry] and weight string. */
+    fun calculateScore(entry: Entry, weight: String): Int {
+        val proteinGoal = proteinGoalForWeightString(weight)
+        return calculateScore(entry.proteinGrams, proteinGoal, entry.vegetableServings, 5, entry.steps, 8500)
+    }
+
+    /**
+     * Format metrics into a single text block that includes the calculated score.
+     */
+    fun formatMetrics(entry: Entry, weight: String): String {
+        val score = calculateScore(entry, weight)
+        return "Score: $score | Protein: ${entry.proteinGrams}g | Veggies: ${entry.vegetableServings} | Steps: ${entry.steps}"
+    }
+}

--- a/app/src/test/java/com/example/timeblock/ScoreUtilsTest.kt
+++ b/app/src/test/java/com/example/timeblock/ScoreUtilsTest.kt
@@ -1,0 +1,38 @@
+package com.example.timeblock
+
+import com.example.timeblock.data.entity.Entry
+import com.example.timeblock.util.ScoreUtils
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.Instant
+
+class ScoreUtilsTest {
+    private fun entry(p: Int, v: Int, s: Int) = Entry(
+        proteinGrams = p,
+        vegetableServings = v,
+        steps = s,
+        timeCreated = Instant.EPOCH,
+        timeModified = Instant.EPOCH
+    )
+
+    @Test
+    fun perfectScore() {
+        val e = entry(100, 5, 8500)
+        val score = ScoreUtils.calculateScore(e, "100 kg")
+        assertEquals(100, score)
+    }
+
+    @Test
+    fun halfScore() {
+        val e = entry(50, 2, 4250)
+        val score = ScoreUtils.calculateScore(e, "100 kg")
+        assertEquals(50, score)
+    }
+
+    @Test
+    fun cappedScore() {
+        val e = entry(200, 10, 20000)
+        val score = ScoreUtils.calculateScore(e, "100 kg")
+        assertEquals(100, score)
+    }
+}


### PR DESCRIPTION
## Summary
- add `ScoreUtils` for calculating and formatting a daily score
- allow Home screen to share score text via share sheet
- cover score calculation with unit tests

## Testing
- `./gradlew testDebugUnitTest` *(fails: No route to host)*