### PR TITLE
Add history entry editing dialog

### DIFF
--- a/app/src/main/java/com/example/timeblock/data/Repository.kt
+++ b/app/src/main/java/com/example/timeblock/data/Repository.kt
@@ -96,6 +96,17 @@ class Repository(private val userDao: UserDao, private val entryDao: EntryDao) {
         return updatedEntry
     }
 
+    suspend fun updateEntry(entry: Entry, protein: Int, vegetables: Int, steps: Int): Entry {
+        val updated = entry.copy(
+            proteinGrams = protein,
+            vegetableServings = vegetables,
+            steps = steps,
+            timeModified = Instant.now()
+        )
+        entryDao.insert(updated)
+        return updated
+    }
+
     fun getTodayEntryFlow(): Flow<Entry> = flow {
         emit(getOrCreateTodayEntry())
     }

--- a/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
@@ -42,6 +42,13 @@ class HistoryViewModel(private val repository: Repository) : ViewModel() {
         }
     }
 
+    fun updateEntry(entry: Entry, protein: Int, vegetables: Int, steps: Int) {
+        viewModelScope.launch {
+            repository.updateEntry(entry, protein, vegetables, steps)
+            loadEntries(currentRange)
+        }
+    }
+
     class HistoryViewModelFactory(private val repository: Repository) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(HistoryViewModel::class.java)) {


### PR DESCRIPTION
## Summary
- support updating entries in Repository
- enable editing entries in HistoryViewModel
- add EditEntryDialog and edit icon on History screen

## Testing
- `./gradlew compileAll` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b3e53bd1c8322ab8e9717defad526