### PR TITLE
Add signing config from keystore.properties

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,9 +4,30 @@ plugins {
     id("com.google.devtools.ksp")
 }
 
+import java.util.Properties
+import java.io.FileInputStream
+
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystoreProperties = Properties()
+if (keystorePropertiesFile.exists()) {
+    FileInputStream(keystorePropertiesFile).use { keystoreProperties.load(it) }
+}
+
 android {
     namespace = "com.example.timeblock"
     compileSdk = 34
+
+    signingConfigs {
+        create("release") {
+            val storeFilePath = keystoreProperties["storeFile"] as String?
+            if (storeFilePath != null) {
+                storeFile = file(storeFilePath)
+            }
+            storePassword = keystoreProperties["storePassword"] as String?
+            keyAlias = keystoreProperties["keyAlias"] as String?
+            keyPassword = keystoreProperties["keyPassword"] as String?
+        }
+    }
 
     defaultConfig {
         applicationId = "com.example.timeblock"
@@ -23,6 +44,7 @@ android {
 
     buildTypes {
         release {
+            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),

--- a/keystore.properties
+++ b/keystore.properties
@@ -1,0 +1,4 @@
+storeFile=release.keystore
+storePassword=changeit
+keyAlias=my-key-alias
+keyPassword=changeit


### PR DESCRIPTION
## Summary
- load keystore credentials from a `keystore.properties` file
- define a `release` signing config
- apply that signing config to the release build type
- add example `keystore.properties`

## Testing
- `./gradlew assembleDebug` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b3f5c03f08322a2245afa1948c5cd