### PR TITLE
Improve history ordering and graphs

### DIFF
--- a/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
@@ -27,11 +27,12 @@ class HistoryViewModel(private val repository: Repository) : ViewModel() {
     fun loadEntries(range: HistoryRange = currentRange) {
         viewModelScope.launch {
             currentRange = range
-            _entries.value = when (range) {
+            val list = when (range) {
                 HistoryRange.MAX -> repository.getAllEntries()
                 HistoryRange.DAYS_30 -> repository.getEntriesSince(30)
                 HistoryRange.DAYS_5 -> repository.getEntriesSince(5)
             }
+            _entries.value = list.sortedByDescending { it.timeCreated }
         }
     }
 


### PR DESCRIPTION
## Summary
- sort history entries by newest first in HistoryViewModel
- always load full history when opening HistoryScreen
- make HistoryScreen's list scrollable with padding so FABs don't cover content
- replace combined line graph with three labeled metric graphs

## Testing
- `bash gradlew compileAll` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b53132c7483228230388f00d55cd0