### PR TITLE
Update features for entry deletion and graph filters

### DIFF
--- a/app/src/main/java/com/example/timeblock/data/dao/EntryDao.kt
+++ b/app/src/main/java/com/example/timeblock/data/dao/EntryDao.kt
@@ -20,4 +20,7 @@ interface EntryDao {
 
     @Query("SELECT * FROM Entry WHERE entryId = :id")
     suspend fun getEntryById(id: Int): Entry?
+
+    @Query("DELETE FROM Entry WHERE entryId = :id")
+    suspend fun deleteById(id: Int)
 }

--- a/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
@@ -18,15 +18,16 @@ class HistoryViewModel(private val repository: Repository) : ViewModel() {
     private val _entries = MutableStateFlow<List<Entry>>(emptyList())
     val entries: StateFlow<List<Entry>> = _entries.asStateFlow()
 
-    private var currentRange: HistoryRange = HistoryRange.DAYS_5
+    private val _currentRange = MutableStateFlow(HistoryRange.DAYS_5)
+    val currentRange: StateFlow<HistoryRange> = _currentRange.asStateFlow()
 
     init {
         loadEntries()
     }
 
-    fun loadEntries(range: HistoryRange = currentRange) {
+    fun loadEntries(range: HistoryRange = _currentRange.value) {
         viewModelScope.launch {
-            currentRange = range
+            _currentRange.value = range
             val list = when (range) {
                 HistoryRange.MAX -> repository.getAllEntries()
                 HistoryRange.DAYS_30 -> repository.getEntriesSince(30)
@@ -39,14 +40,21 @@ class HistoryViewModel(private val repository: Repository) : ViewModel() {
     fun addEntry(date: LocalDate) {
         viewModelScope.launch {
             repository.insertEntryOn(date)
-            loadEntries(currentRange)
+            loadEntries(_currentRange.value)
         }
     }
 
     fun updateEntry(entry: Entry, protein: Int, vegetables: Int, steps: Int) {
         viewModelScope.launch {
             repository.updateEntry(entry, protein, vegetables, steps)
-            loadEntries(currentRange)
+            loadEntries(_currentRange.value)
+        }
+    }
+
+    fun deleteEntry(entry: Entry) {
+        viewModelScope.launch {
+            repository.deleteEntry(entry)
+            loadEntries(_currentRange.value)
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent duplicate entries on a single day
- allow deleting entries from the edit dialog with confirmation
- remember chosen range on the line graph screen

## Testing
- `./gradlew compileAll` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b5632f27c8322981e7239d0f45b9e