### PR TITLE
Add updateCurrentRange option to HistoryViewModel.loadEntries

### DIFF
--- a/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
@@ -22,12 +22,17 @@ class HistoryViewModel(private val repository: Repository) : ViewModel() {
     val currentRange: StateFlow<HistoryRange> = _currentRange.asStateFlow()
 
     init {
-        loadEntries()
+        loadEntries(_currentRange.value)
     }
 
-    fun loadEntries(range: HistoryRange = _currentRange.value) {
+    fun loadEntries(
+        range: HistoryRange = _currentRange.value,
+        updateCurrentRange: Boolean = true
+    ) {
         viewModelScope.launch {
-            _currentRange.value = range
+            if (updateCurrentRange) {
+                _currentRange.value = range
+            }
             val list = when (range) {
                 HistoryRange.MAX -> repository.getAllEntries()
                 HistoryRange.DAYS_30 -> repository.getEntriesSince(30)

--- a/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
+++ b/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
@@ -729,7 +729,9 @@ fun HistoryScreen(
 ) {
     val entries by viewModel.entries.collectAsState()
     // Always show the full history regardless of previous graph range
-    LaunchedEffect(Unit) { viewModel.loadEntries(HistoryRange.MAX) }
+    LaunchedEffect(Unit) {
+        viewModel.loadEntries(HistoryRange.MAX, updateCurrentRange = false)
+    }
     var showPicker by remember { mutableStateOf(false) }
     var editingEntry by remember { mutableStateOf<Entry?>(null) }
     val context = LocalContext.current


### PR DESCRIPTION
## Summary
- add `updateCurrentRange` parameter to `loadEntries`
- keep current range immutable when loading initial history and HistoryScreen
- call `loadEntries` in HistoryScreen without updating the range

## Testing
- `./gradlew buildAndCheck` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b5cc83c40832297eb8b1c1ab44736