### PR TITLE
Improve line chart scaling

### DIFF
--- a/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
+++ b/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
@@ -979,10 +979,12 @@ fun SingleLineGraph(
 ) {
     val sorted = entries.sortedBy { it.timeCreated }
     val maxValue = sorted.maxOfOrNull { valueSelector(it) }?.coerceAtLeast(1) ?: 1
+    val minValue = sorted.minOfOrNull { valueSelector(it) } ?: 0
+    val range = (maxValue - minValue).coerceAtLeast(1)
 
     Column(modifier = modifier) {
         Row(modifier = Modifier.weight(1f)) {
-            val step = (maxValue / 4f).roundToInt()
+            val step = range / 4f
             Column(
                 modifier = Modifier
                     .fillMaxHeight()
@@ -990,9 +992,12 @@ fun SingleLineGraph(
                 verticalArrangement = Arrangement.SpaceBetween
             ) {
                 for (i in 4 downTo 0) {
-                    Text(text = "${i * step}", style = MaterialTheme.typography.labelSmall)
+                    val value = (minValue + step * i).roundToInt()
+                    Text(text = "$value", style = MaterialTheme.typography.labelSmall)
                 }
             }
+
+            val strokeWidth = with(LocalDensity.current) { 1.dp.toPx() }
 
             Canvas(modifier = Modifier
                 .weight(1f)
@@ -1001,9 +1006,21 @@ fun SingleLineGraph(
             val xStep = if (sorted.size > 1) size.width / (sorted.size - 1) else 0f
             val path = Path()
 
+            // Draw horizontal grid lines
+            for (i in 0..4) {
+                val value = minValue + step * i
+                val yLine = size.height - ((value - minValue) / range.toFloat()) * size.height
+                drawLine(
+                    color = Color.LightGray,
+                    start = Offset(0f, yLine),
+                    end = Offset(size.width, yLine),
+                    strokeWidth = strokeWidth
+                )
+            }
+
             sorted.forEachIndexed { index, entry ->
                 val x = index * xStep
-                val y = size.height - (valueSelector(entry).toFloat() / maxValue) * size.height
+                val y = size.height - ((valueSelector(entry) - minValue).toFloat() / range.toFloat()) * size.height
                 if (index == 0) {
                     path.moveTo(x, y)
                 } else {


### PR DESCRIPTION
## Summary
- use dynamic minimum value for single line graphs
- draw reference lines across the graph for easier comparison
- fix Composable context when determining stroke width

## Testing
- `./gradlew compileAll --no-daemon` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b5d66affc83229fb844402b9003ea