### PR TITLE
Fix history screen affecting line graph range

### DIFF
--- a/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
+++ b/app/src/main/java/com/example/timeblock/ui/HistoryViewModel.kt
@@ -25,9 +25,11 @@ class HistoryViewModel(private val repository: Repository) : ViewModel() {
         loadEntries()
     }
 
-    fun loadEntries(range: HistoryRange = _currentRange.value) {
+    fun loadEntries(range: HistoryRange = _currentRange.value, updateCurrentRange: Boolean = true) {
         viewModelScope.launch {
-            _currentRange.value = range
+            if (updateCurrentRange) {
+                _currentRange.value = range
+            }
             val list = when (range) {
                 HistoryRange.MAX -> repository.getAllEntries()
                 HistoryRange.DAYS_30 -> repository.getEntriesSince(30)

--- a/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
+++ b/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
@@ -729,7 +729,7 @@ fun HistoryScreen(
 ) {
     val entries by viewModel.entries.collectAsState()
     // Always show the full history regardless of previous graph range
-    LaunchedEffect(Unit) { viewModel.loadEntries(HistoryRange.MAX) }
+    LaunchedEffect(Unit) { viewModel.loadEntries(HistoryRange.MAX, updateCurrentRange = false) }
     var showPicker by remember { mutableStateOf(false) }
     var editingEntry by remember { mutableStateOf<Entry?>(null) }
     val context = LocalContext.current
@@ -884,6 +884,9 @@ fun HistoryScreen(
 fun LineGraphScreen(viewModel: HistoryViewModel, onBack: () -> Unit) {
     val entries by viewModel.entries.collectAsState()
     val range by viewModel.currentRange.collectAsState()
+    LaunchedEffect(Unit) {
+        viewModel.loadEntries(viewModel.currentRange.value, updateCurrentRange = false)
+    }
     Column(
         modifier = Modifier
             .fillMaxSize()


### PR DESCRIPTION
## Summary
- keep HistoryViewModel range when showing history
- use new parameter in HistoryScreen so line graph defaults remain at 5 days
- ensure LineGraph screen loads entries without updating the current range

## Testing
- `./gradlew test` *(fails: No route to host)*


------
https://chatgpt.com/codex/tasks/task_e_683b605a460c832289b7f797415ebd8c