### PR TITLE
Fix duplicate entry creation with Mutex

### DIFF
--- a/app/src/main/java/com/example/timeblock/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/timeblock/ui/MainViewModel.kt
@@ -11,9 +11,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class MainViewModel(private val repository: Repository) : ViewModel() {
 
+    private val loadMutex = Mutex()
     private var lastLoadedDay: LocalDate? = null
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
@@ -55,8 +58,10 @@ class MainViewModel(private val repository: Repository) : ViewModel() {
 
     private fun loadTodayEntry() {
         viewModelScope.launch {
-            _trackingData.value = repository.getOrCreateTodayEntry()
-            lastLoadedDay = LocalDate.now()
+            loadMutex.withLock {
+                _trackingData.value = repository.getOrCreateTodayEntry()
+                lastLoadedDay = LocalDate.now()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- prevent concurrent loads of today's entry by using a Mutex

## Testing
- `./gradlew compileAll` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b927c70ac8322b0d9f7b29227e6d4