### PR TITLE
Integrate Garmin step imports

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -88,6 +88,9 @@ dependencies {
     implementation(libs.androidx.compose.animation.core)
     implementation(libs.kotlinx.datetime)
 
+    // Networking for Garmin API
+    implementation("com.squareup.okhttp3:okhttp:4.10.0")
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/src/main/java/com/example/timeblock/garmin/GarminClient.kt
+++ b/app/src/main/java/com/example/timeblock/garmin/GarminClient.kt
@@ -1,0 +1,37 @@
+package com.example.timeblock.garmin
+
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.time.LocalDate
+
+/**
+ * Simple client used for fetching step data from the Garmin API. This class
+ * only exposes the pieces that the repository currently needs. OAuth
+ * negotiation and actual endpoint details are left as TODOs so that this file
+ * can be expanded later without affecting the rest of the code base.
+ */
+class GarminClient {
+
+    private val http = OkHttpClient()
+
+    /**
+     * Retrieve the list of devices connected to the user's Garmin account.
+     */
+    suspend fun fetchDevices(): List<String> {
+        // TODO: Query Garmin API for device list. Placeholder implementation
+        // returns a single generic device.
+        return listOf("Connected Garmin")
+    }
+
+    /**
+     * Fetch daily step counts from the Garmin API for the authenticated user.
+     *
+     * @return map of [LocalDate] to step count for that day.
+     */
+    suspend fun fetchSteps(): Map<LocalDate, Int> {
+        // TODO: Perform OAuth and real API calls.
+        // This placeholder simply returns an empty map so that the rest of the
+        // application can compile and tests can run without network access.
+        return emptyMap()
+    }
+}

--- a/app/src/main/java/com/example/timeblock/ui/MainViewModel.kt
+++ b/app/src/main/java/com/example/timeblock/ui/MainViewModel.kt
@@ -131,6 +131,13 @@ class MainViewModel(private val repository: Repository) : ViewModel() {
         _isSettings.value = false
     }
 
+    fun importGarminSteps(data: Map<LocalDate, Int>) {
+        viewModelScope.launch {
+            repository.importGarminSteps(data)
+            loadTodayEntry()
+        }
+    }
+
     fun updateUser(user: User, displayName: String, weight: String) {
         viewModelScope.launch {
             val updated = repository.updateUser(user, displayName, weight)

--- a/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
+++ b/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
@@ -626,7 +626,12 @@ fun EditEntryDialog(
 }
 
 @Composable
-fun SettingsScreen(user: User, onSave: (String, String) -> Unit, onBack: () -> Unit) {
+fun SettingsScreen(
+    user: User,
+    onSave: (String, String) -> Unit,
+    onBack: () -> Unit,
+    onImportGarmin: () -> Unit
+) {
     var name by remember { mutableStateOf(user.displayName) }
     var weightVal by remember { mutableStateOf(user.weight.takeWhile { it.isDigit() || it == '.' }) }
     var expanded by remember { mutableStateOf(false) }
@@ -692,6 +697,13 @@ fun SettingsScreen(user: User, onSave: (String, String) -> Unit, onBack: () -> U
             },
             modifier = Modifier.fillMaxWidth()
         ) { Text("Save") }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Button(
+            onClick = onImportGarmin,
+            modifier = Modifier.fillMaxWidth()
+        ) { Text("Import Connected Garmin") }
     }
 }
 

--- a/app/src/test/java/com/example/timeblock/data/RepositoryImportGarminStepsTest.kt
+++ b/app/src/test/java/com/example/timeblock/data/RepositoryImportGarminStepsTest.kt
@@ -1,0 +1,78 @@
+package com.example.timeblock.data
+
+import com.example.timeblock.data.dao.EntryDao
+import com.example.timeblock.data.dao.UserDao
+import com.example.timeblock.data.entity.Entry
+import com.example.timeblock.data.entity.User
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class FakeEntryDao : EntryDao {
+    private val entries = mutableListOf<Entry>()
+    private var nextId = 1
+
+    override suspend fun insert(entry: Entry) {
+        val idx = entries.indexOfFirst { it.entryId == entry.entryId && entry.entryId != 0 }
+        if (entry.entryId == 0) {
+            entries.add(entry.copy(entryId = nextId++))
+        } else if (idx >= 0) {
+            entries[idx] = entry
+        } else {
+            entries.add(entry)
+        }
+    }
+
+    override suspend fun getAllEntries(): List<Entry> = entries.toList()
+
+    override suspend fun getEntriesBetween(start: Instant, end: Instant): List<Entry> {
+        return entries.filter { it.timeCreated >= start && it.timeCreated <= end }
+    }
+
+    override suspend fun getEntryById(id: Int): Entry? = entries.find { it.entryId == id }
+
+    override suspend fun deleteById(id: Int) { entries.removeIf { it.entryId == id } }
+}
+
+class FakeUserDao : UserDao {
+    override suspend fun insert(user: User) {}
+    override suspend fun getAllUsers(): List<User> = emptyList()
+    override suspend fun updateUser(displayName: String, weight: String, timeModified: Instant, userUuid: String) {}
+}
+
+class RepositoryImportGarminStepsTest {
+    private lateinit var repository: Repository
+    private lateinit var entryDao: FakeEntryDao
+
+    @Before
+    fun setup() {
+        entryDao = FakeEntryDao()
+        repository = Repository(FakeUserDao(), entryDao)
+    }
+
+    @Test
+    fun createsNewEntryWhenMissing() = runBlocking {
+        val date = LocalDate.now().minusDays(1)
+        repository.importGarminSteps(mapOf(date to 100))
+        val start = date.atStartOfDay(ZoneId.systemDefault()).toInstant()
+        val end = date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant().minusMillis(1)
+        val entries = entryDao.getEntriesBetween(start, end)
+        assertEquals(1, entries.size)
+        assertEquals(100, entries.first().steps)
+    }
+
+    @Test
+    fun updatesExistingEntry() = runBlocking {
+        val date = LocalDate.now().minusDays(1)
+        repository.insertEntryOn(date)
+        repository.importGarminSteps(mapOf(date to 200))
+        val start = date.atStartOfDay(ZoneId.systemDefault()).toInstant()
+        val end = date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant().minusMillis(1)
+        val entry = entryDao.getEntriesBetween(start, end).first()
+        assertEquals(200, entry.steps)
+    }
+}


### PR DESCRIPTION
## Summary
- add OkHttp dependency for network
- create GarminClient skeleton
- support Garmin step imports in repository and view model
- expose button on Settings screen to import steps
- show basic Garmin device dialog in MainActivity
- add unit tests for Garmin step importing
- **fix coroutine import**

## Testing
- `./gradlew compileAll --no-daemon` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683b98df8dc88322b6bbb926fd0c0600