### PR TITLE
Remove time from history entries

### DIFF
--- a/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
+++ b/app/src/main/java/com/example/timeblock/ui/screens/AppScreens.kt
@@ -804,12 +804,10 @@ fun HistoryScreen(
                             val ldt = entry.timeCreated
                                 .toKotlinInstant()
                                 .toLocalDateTime(TimeZone.currentSystemDefault())
-                            val formattedDate = "%04d-%02d-%02d %02d:%02d".format(
+                            val formattedDate = "%04d-%02d-%02d".format(
                                 ldt.year,
                                 ldt.monthNumber,
-                                ldt.dayOfMonth,
-                                ldt.hour,
-                                ldt.minute
+                                ldt.dayOfMonth
                             )
                             val clipboard = LocalClipboardManager.current
                             Row(


### PR DESCRIPTION
## Summary
- simplify date formatting in HistoryScreen entries to remove the hour and minute

## Testing
- `./gradlew test` *(fails: unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68646ce03ec48322a690ec7a01582275