### PR TITLE
Integrate Garmin step count via Health Connect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -98,6 +98,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.health.connect.client)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/timeblock/MainActivity.kt
+++ b/app/src/main/java/com/example/timeblock/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.lifecycleScope
 import com.example.timeblock.data.AppDatabase
 import com.example.timeblock.data.Repository
 import com.example.timeblock.ui.MainViewModel
@@ -23,10 +24,14 @@ import com.example.timeblock.ui.screens.SettingsScreen
 import com.example.timeblock.ui.HistoryViewModel
 import com.example.timeblock.ui.screens.LineGraphScreen
 import com.example.timeblock.ui.theme.TimeBlockTheme
+import com.example.timeblock.util.GarminHealthConnectStepsProvider
+import com.example.timeblock.util.StepCountProvider
+import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
 
     private lateinit var viewModel: MainViewModel
+    private lateinit var stepCountProvider: StepCountProvider
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -36,6 +41,7 @@ class MainActivity : ComponentActivity() {
         val viewModelFactory = MainViewModel.MainViewModelFactory(repository)
         viewModel = ViewModelProvider(this, viewModelFactory)[MainViewModel::class.java]
         val historyFactory = HistoryViewModel.HistoryViewModelFactory(repository)
+        stepCountProvider = GarminHealthConnectStepsProvider(this)
 
         setContent {
             TimeBlockTheme {
@@ -52,6 +58,12 @@ class MainActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         viewModel.refreshForDateChange()
+        lifecycleScope.launch {
+            val steps = stepCountProvider.getTodaySteps().toInt()
+            if (steps > 0) {
+                viewModel.updateValue(steps, isAddition = false)
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/example/timeblock/util/GarminHealthConnectStepsProvider.kt
+++ b/app/src/main/java/com/example/timeblock/util/GarminHealthConnectStepsProvider.kt
@@ -1,0 +1,37 @@
+package com.example.timeblock.util
+
+import android.content.Context
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.aggregate.AggregateRequest
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.time.TimeRangeFilter
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+interface StepCountProvider {
+    suspend fun getTodaySteps(): Long
+}
+
+class GarminHealthConnectStepsProvider(private val context: Context) : StepCountProvider {
+    private val client: HealthConnectClient = HealthConnectClient.getOrCreate(context)
+    private val permissions = setOf(
+        HealthPermission.getReadPermission(StepsRecord::class)
+    )
+
+    override suspend fun getTodaySteps(): Long {
+        val granted = client.permissionController.getGrantedPermissions(permissions)
+        if (!granted.containsAll(permissions)) {
+            return 0L
+        }
+        val end = Instant.now()
+        val start = LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant()
+        val request = AggregateRequest(
+            metrics = setOf(StepsRecord.COUNT_TOTAL),
+            timeRangeFilter = TimeRangeFilter.between(start, end)
+        )
+        val response = client.aggregate(request)
+        return response[StepsRecord.COUNT_TOTAL] ?: 0L
+    }
+}

--- a/app/src/test/java/com/example/timeblock/util/GarminStepsProviderTest.kt
+++ b/app/src/test/java/com/example/timeblock/util/GarminStepsProviderTest.kt
@@ -1,0 +1,16 @@
+package com.example.timeblock.util
+
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GarminStepsProviderTest {
+    @Test
+    fun forerunner255SampleSteps() = runBlocking {
+        val sampleSteps = 7890L // sample steps from a Garmin Forerunner 255
+        val provider = object : StepCountProvider {
+            override suspend fun getTodaySteps(): Long = sampleSteps
+        }
+        assertEquals(sampleSteps, provider.getTodaySteps())
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ lifecycleRuntimeKtx = "2.6.2"
 activityCompose = "1.8.0"
 androidx-lifecycle = "2.6.2"
 composeBom = "2023.10.01" # Downgraded to match Kotlin 1.9.22 and kotlinCompilerExtensionVersion 1.5.8
+healthConnect = "1.1.0-alpha06"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -33,6 +34,7 @@ androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "l
 androidx-compose-animation = { group = "androidx.compose.animation", name = "animation" }
 androidx-compose-animation-core = { group = "androidx.compose.animation", name = "animation-core" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }
+androidx-health-connect-client = { group = "androidx.health.connect", name = "client", version.ref = "healthConnect" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add Health Connect dependency and Garmin step count provider
- sync Garmin steps on resume and provide basic unit test

## Testing
- `./gradlew compileAll` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fd8ffe848322abd318b3dbf5f5ff